### PR TITLE
Fix DashWrapper hydration cache eviction guard on latest-dash

### DIFF
--- a/dash/dash-renderer/src/reducers/reducer.js
+++ b/dash/dash-renderer/src/reducers/reducer.js
@@ -27,7 +27,12 @@ export const apiRequests = [
     'loginRequest'
 ];
 
-const layoutHashes = (state = {}, action) => {
+const initialLayoutHashState = {
+    entries: {},
+    index: {}
+};
+
+const layoutHashes = (state = initialLayoutHashState, action) => {
     if (
         includes(action.type, [
             'UNDO_PROP_CHANGE',
@@ -39,16 +44,33 @@ const layoutHashes = (state = {}, action) => {
         // render on the parent containers.
         const actionPath = action.payload.itempath;
         const strPath = stringifyPath(actionPath);
-        const prev = pathOr(0, [strPath, 'hash'], state);
-        state = assoc(
+        const prevHash = pathOr(0, ['entries', strPath, 'hash'], state);
+
+        const nextEntries = assoc(
             strPath,
             {
-                hash: prev + 1,
+                hash: prevHash + 1,
                 changedProps: action.payload.props,
                 renderType: action.payload.renderType
             },
-            state
+            state.entries
         );
+
+        const segments = strPath.split(',');
+        let current = '';
+        const nextIndex = {...state.index};
+        for (let i = 0; i < segments.length; i++) {
+            current = current ? `${current},${segments[i]}` : segments[i];
+            const existing = pathOr([], [current], nextIndex);
+            if (!existing.includes(strPath)) {
+                nextIndex[current] = existing.concat(strPath);
+            }
+        }
+
+        state = {
+            entries: nextEntries,
+            index: nextIndex
+        };
     }
     return state;
 };

--- a/dash/dash-renderer/src/wrapper/DashWrapper.tsx
+++ b/dash/dash-renderer/src/wrapper/DashWrapper.tsx
@@ -1,4 +1,10 @@
-import React, {useCallback, MutableRefObject, useRef, useMemo} from 'react';
+import React, {
+    useCallback,
+    MutableRefObject,
+    useRef,
+    useMemo,
+    useEffect
+} from 'react';
 import {
     path,
     concat,
@@ -64,6 +70,9 @@ function DashWrapper({
 }: DashWrapperProps) {
     const dispatch = useDispatch();
     const memoizedKeys: MutableRefObject<MemoizedKeysType> = useRef({});
+    const hydrationCache = useRef<Map<string, React.ReactNode | null>>(
+        new Map()
+    );
     const newRender = useRef(false);
     const renderedPath = useRef<DashLayoutPath>(componentPath);
     let renderComponent: any = null;
@@ -81,18 +90,35 @@ function DashWrapper({
     renderComponentProps = componentProps;
     renderH = h;
 
-    useMemo(() => {
+    const pathKey = useMemo(
+        () => stringifyPath(componentPath),
+        [componentPath]
+    );
+
+    useEffect(() => {
+        renderedPath.current = componentPath;
+    }, [componentPath]);
+
+    useEffect(() => {
+        const cache = hydrationCache.current;
         if (_newRender) {
             newRender.current = true;
             renderH = 0;
+            // purge any cached hydration for this path so the next render rebuilds
+            const toDelete: string[] = [];
+            cache.forEach((_, key) => {
+                if (key.startsWith(`${pathKey}|`)) {
+                    toDelete.push(key);
+                }
+            });
+            toDelete.forEach(key => cache.delete(key));
             if (renderH in memoizedKeys.current) {
                 delete memoizedKeys.current[renderH];
             }
         } else {
             newRender.current = false;
         }
-        renderedPath.current = componentPath;
-    }, [_newRender]);
+    }, [_newRender, pathKey]);
 
     const setProps = (newProps: UpdatePropsPayload) => {
         const {id} = renderComponentProps;
@@ -432,6 +458,8 @@ function DashWrapper({
         return props;
     };
 
+    const hydrationKey = `${pathKey}|${renderH}`;
+
     const hydrateFunc = () => {
         if (newRender.current) {
             renderComponent = _passedComponent;
@@ -459,7 +487,7 @@ function DashWrapper({
         }
         newRender.current = false;
 
-        return config.props_check ? (
+        const hydratedElement = config.props_check ? (
             <CheckedComponent
                 element={element}
                 props={hydratedProps}
@@ -475,17 +503,40 @@ function DashWrapper({
         ) : (
             createElement(element, hydratedProps, extraProps, hydratedChildren)
         );
+
+        return hydratedElement;
     };
 
     let hydrated = null;
-    if (renderH in memoizedKeys.current && !newRender.current) {
-        hydrated = React.isValidElement(memoizedKeys.current[renderH])
-            ? memoizedKeys.current[renderH]
-            : null;
+    if (!newRender.current) {
+        const cachedHydration = hydrationCache.current.get(hydrationKey);
+        if (cachedHydration !== undefined) {
+            hydrated = cachedHydration;
+        } else if (renderH in memoizedKeys.current) {
+            const memoized = memoizedKeys.current[renderH];
+            hydrated = React.isValidElement(memoized) ? memoized : null;
+        }
     }
     if (!hydrated) {
         hydrated = hydrateFunc();
-        memoizedKeys.current = {[renderH]: hydrated};
+        memoizedKeys.current[renderH] = hydrated;
+    }
+
+    if (!newRender.current && hydrationKey) {
+        const cache = hydrationCache.current;
+        if (!cache.has(hydrationKey)) {
+            // Maintain insertion order to implement a simple LRU eviction.
+            cache.set(hydrationKey, hydrated);
+            const MAX_CACHE_SIZE = 50;
+            if (cache.size > MAX_CACHE_SIZE) {
+                const firstKey = cache.keys().next().value;
+                if (firstKey) {
+                    cache.delete(firstKey);
+                }
+            }
+        } else if (hydrated !== cache.get(hydrationKey)) {
+            cache.set(hydrationKey, hydrated);
+        }
     }
 
     return renderComponent ? (

--- a/dash/dash-renderer/src/wrapper/selectors.ts
+++ b/dash/dash-renderer/src/wrapper/selectors.ts
@@ -43,13 +43,25 @@ const isFirstLevelPropsChild = (
 };
 
 function determineChangedProps(
-    state: any,
+    layoutHashes: any,
     strPath: string
 ): ChangedPropsRecord {
     let combinedHash = 0;
     let renderType: any; // Default render type, adjust as needed
     const changedProps: Record<string, any> = {};
-    Object.entries(state.layoutHashes).forEach(([updatedPath, pathHash]) => {
+    const relevantPaths = pathOr([], ['index', strPath], layoutHashes);
+    const entries = layoutHashes.entries || {};
+    const pathsToCheck = relevantPaths.length
+        ? relevantPaths
+        : entries[strPath]
+        ? [strPath]
+        : [];
+
+    pathsToCheck.forEach(updatedPath => {
+        const pathHash = entries[updatedPath];
+        if (!pathHash) {
+            return;
+        }
         const [descendant, remainingSegments] = isFirstLevelPropsChild(
             updatedPath,
             strPath
@@ -91,9 +103,9 @@ export const selectDashProps =
 
         let hash;
         if (checkDashChildrenUpdate(c)) {
-            hash = determineChangedProps(state, strPath);
+            hash = determineChangedProps(state.layoutHashes, strPath);
         } else {
-            hash = state.layoutHashes[strPath];
+            hash = pathOr(undefined, ['entries', strPath], state.layoutHashes);
         }
         let h = 0;
         let changedProps: object = {};


### PR DESCRIPTION
### Motivation
- Reduce repeated hydration and global layout scans that amplify provider-triggered re-renders by introducing path-scoped caching and indexed layout-hash lookups. 
- Address a TypeScript runtime issue encountered when running the renderer test build after integrating recent dash core updates.

### Description
- Add a path-scoped hydration cache in `dash/dash-renderer/src/wrapper/DashWrapper.tsx` with a simple LRU eviction, persistent `memoizedKeys`, `pathKey` memoization, and targeted invalidation on forced renders. 
- Restructure the layout-hash reducer in `dash/dash-renderer/src/reducers/reducer.js` to store `entries` and an `index` mapping so lookups for affected subpaths are O(1) instead of scanning the whole map. 
- Update selector logic in `dash/dash-renderer/src/wrapper/selectors.ts` to consume the new `layoutHashes` shape and limit checks to relevant indexed paths only. 
- Add a small safety guard around LRU eviction in `DashWrapper` to avoid calling `Map.delete` with an undefined key, which fixed the TypeScript compile error surfaced during the test build.

### Testing
- Ran `npm run private::lint.renderer`, which completed successfully. 
- Ran `cd dash/dash-renderer && npm test -- --runInBand`, and the webpack/TypeScript build phase completed (TypeScript error resolved); the Karma browser tests could not execute in this environment because no Chrome binary was available (`Please, set "CHROME_BIN" env variable`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915e220f56c832e91ee186c45682eab)